### PR TITLE
Add OpenClaw Monitor - open-source dashboard for OpenClaw AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Please review our [CONTRIBUTING.md](https://github.com/EthicalML/awesome-product
 * [IntellAgent](https://github.com/plurai-ai/intellagent) ![](https://img.shields.io/github/stars/plurai-ai/intellagent.svg?cacheSeconds=86400) - IntellAgent is an advanced multi-agent framework that transforms the evaluation and optimization of conversational agents.
 * [Judgeval](https://github.com/JudgmentLabs/judgeval) ![](https://img.shields.io/github/stars/JudgmentLabs/judgeval.svg?cacheSeconds=86400) - Judgeval is an open-source framework for agent behavior monitoring. Judgeval offers a toolkit to track and judge agent behavior in online and offline setups, enabling you to convert interaction data from production/test environments into improved agents.
 * [Manifest](https://github.com/mnfst/manifest) ![](https://img.shields.io/github/stars/mnfst/manifest.svg?cacheSeconds=86400) - Manifest is open-source observability for AI agents. Track costs, tokens, messages, and performance — entirely on your machine.
+* [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) ![](https://img.shields.io/github/stars/flik2002/openclaw-monitor.svg?cacheSeconds=86400) - OpenClaw Monitor is a free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, multi-model support (GPT/Claude/Gemini), JWT auth, and multi-language (Chinese/English).
 
 ## Agent Protocols
 


### PR DESCRIPTION
## OpenClaw Monitor

**Repository:** https://github.com/flik2002/openclaw-monitor

A free open-source monitoring dashboard for OpenClaw AI agents — featuring token usage tracking, session monitoring, 7-day trend visualization, multi-model support (GPT/Claude/Gemini), JWT authentication, and multi-language support (Chinese/English).

**Why it fits this list:** OpenClaw Monitor is the only open-source dashboard purpose-built for the OpenClaw agent framework, filling a gap in the production observability tooling for agentic systems. It helps teams deploy, monitor, and scale OpenClaw agents in production.

---
*Submitted via automated promotion workflow — July 2026*